### PR TITLE
Fix Browserify error module 'type'

### DIFF
--- a/app/app.coffee
+++ b/app/app.coffee
@@ -1,7 +1,7 @@
 # Get Windows colors, type ramp, and motion library out of the box
 # For more info see https://github.com/Microsoft/windows-framer-toolkit
 {SystemColor} = require 'SystemColor'
-{Type} = require 'type'
+{Type} = require 'Type'
 motion = require 'motionCurves'
 
 # If you want the purple outlines, comment this out


### PR DESCRIPTION
Browserify compile error: Error: Cannot find module 'type'. Type need an uppercase.